### PR TITLE
Revamp team section layout

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -658,25 +658,24 @@ body {
 /* Team grid */
 .team-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(220px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
     gap: 24px;
-    align-items: stretch;
+    margin-top: 32px;
 }
 
-/* адаптив */
 @media (max-width: 1200px) {
     .team-grid {
-        grid-template-columns: repeat(3, minmax(220px, 1fr));
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 
 @media (max-width: 900px) {
     .team-grid {
-        grid-template-columns: repeat(2, minmax(200px, 1fr));
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 
-@media (max-width: 560px) {
+@media (max-width: 600px) {
     .team-grid {
         grid-template-columns: 1fr;
     }
@@ -686,55 +685,47 @@ body {
 .team-card {
     background: #fff;
     border-radius: 12px;
-    box-shadow: 0 2px 12px hsl(25 15% 85% / 0.15);
-    padding: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
     text-align: center;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+    padding: 16px;
     transition: transform .2s ease, box-shadow .2s ease;
 }
 
 .team-card:hover {
     transform: translateY(-3px);
-    box-shadow: 0 8px 24px hsl(25 25% 35% / 0.12);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
-/* Фото сверху, квадрат, не «ломается» */
 .team-photo {
     aspect-ratio: 1 / 1;
     border-radius: 10px;
     overflow: hidden;
-    background: hsl(30, 10%, 92%);
+    background: #f3f3f3;
+    margin-bottom: 12px;
 }
 
 .team-photo img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    display: block;
 }
 
-/* Тексты */
 .team-name {
-    margin-top: 12px;
-    font-size: 1.05rem;
+    font-size: 1rem;
     font-weight: 600;
+    margin-bottom: 4px;
     color: hsl(25, 25%, 35%);
 }
 
 .team-role {
-    margin-top: 4px;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     color: hsl(25, 6%, 45%);
 }
 
-/* Пустое состояние */
 .team-empty {
-    color: hsl(25, 6%, 45%);
-    text-align: center;
     grid-column: 1 / -1;
-    padding: 16px 0;
+    text-align: center;
+    color: hsl(25, 6%, 45%);
 }
 
 .mission-section {

--- a/templates/about.html
+++ b/templates/about.html
@@ -61,13 +61,13 @@
 
                     <div class="team-grid">
                         {% for m in team %}
-                        <article class="team-card">
+                        <div class="team-card">
                             <div class="team-photo">
                                 <img src="/media/{{ m.photo }}" alt="{{ m.full_name }}">
                             </div>
                             <h3 class="team-name">{{ m.full_name }}</h3>
                             <p class="team-role">{{ m.role }}</p>
-                        </article>
+                        </div>
                         {% empty %}
                         <p class="team-empty">Команда будет опубликована позже.</p>
                         {% endfor %}


### PR DESCRIPTION
## Summary
- rework the "Наша команда" section markup so team members render as cards
- style the team grid for responsive columns with polished card visuals and hover effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbb4c7b3008328922d282a72f80148