### PR TITLE
Make category filters horizontally scrollable

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -79,6 +79,50 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
+function makeHorizontalScroll(el) {
+    if (!el) return;
+    let isDown = false;
+    let startX = 0;
+    let scrollLeft = 0;
+
+    // Drag to scroll (мышью)
+    el.addEventListener('mousedown', (e) => {
+        isDown = true;
+        startX = e.pageX - el.offsetLeft;
+        scrollLeft = el.scrollLeft;
+        el.classList.add('dragging');
+    });
+    window.addEventListener('mouseup', () => {
+        isDown = false;
+        el.classList.remove('dragging');
+    });
+    el.addEventListener('mouseleave', () => {
+        isDown = false;
+        el.classList.remove('dragging');
+    });
+    el.addEventListener('mousemove', (e) => {
+        if (!isDown) return;
+        e.preventDefault();
+        const x = e.pageX - el.offsetLeft;
+        const walk = (x - startX);
+        el.scrollLeft = scrollLeft - walk;
+    });
+
+    // Вертикальное колесо → горизонтальный скролл
+    el.addEventListener('wheel', (e) => {
+        // если пользователь крутит вертикально — скроллим вбок
+        if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+            el.scrollLeft += e.deltaY;
+            e.preventDefault();
+        }
+    }, { passive: false });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const scroller = document.getElementById('catScroller');
+    makeHorizontalScroll(scroller);
+});
+
 // Catalog filtering functionality
 function filterProducts(category) {
     const products = document.querySelectorAll('.product-card[data-category]');

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -556,6 +556,41 @@ body {
     border-color: hsl(25, 25%, 35%);
 }
 
+/* Горизонтальная карусель категорий без стрелок */
+.category-scroller {
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+    max-width: 100%;
+    width: 100%;
+    margin-bottom: 40px;
+    padding-bottom: 8px;
+    overscroll-behavior-x: contain;
+}
+
+.category-scroller .filter-btn {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+}
+
+/* Скрыть/смягчить горизонтальный скроллбар (доступность сохраняется) */
+.category-scroller::-webkit-scrollbar { height: 6px; }
+.category-scroller::-webkit-scrollbar-track { background: transparent; }
+.category-scroller::-webkit-scrollbar-thumb {
+    background: hsl(30 12% 88%);
+    border-radius: 4px;
+}
+
+/* При узких экранах кнопки остаются горизонтальными — без переносов */
+@media (max-width: 768px) {
+    .category-scroller { gap: 10px; }
+}
+
+.category-filters { display: contents; }
+
 .no-products {
     text-align: center;
     padding: 60px 0;

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -16,10 +16,12 @@
             <div class="container">
                 <!-- Category Filters -->
                 <div class="category-filters">
-                    <button class="filter-btn {% if not active_category %}active{% endif %}" onclick="filterProducts('all'); window.location.href='{% url 'catalog' %}{% if q %}?q={{ q|urlencode }}{% endif %}';">Все</button>
-                    {% for category in categories %}
-                    <button class="filter-btn {% if active_category and active_category.id == category.id %}active{% endif %}" onclick="filterProducts('{{ category.name }}'); window.location.href='{% url 'catalog' %}?category={{ category.slug }}{% if q %}&q={{ q|urlencode }}{% endif %}';">{{ category.name }}</button>
-                    {% endfor %}
+                    <div class="category-scroller" id="catScroller" aria-label="Категории">
+                        <button class="filter-btn {% if not active_category %}active{% endif %}" onclick="filterProducts('all'); window.location.href='{% url 'catalog' %}{% if q %}?q={{ q|urlencode }}{% endif %}';">Все</button>
+                        {% for category in categories %}
+                        <button class="filter-btn {% if active_category and active_category.id == category.id %}active{% endif %}" onclick="filterProducts('{{ category.name }}'); window.location.href='{% url 'catalog' %}?category={{ category.slug }}{% if q %}&q={{ q|urlencode }}{% endif %}';">{{ category.name }}</button>
+                        {% endfor %}
+                    </div>
                 </div>
 
                 <!-- Products Grid -->


### PR DESCRIPTION
## Summary
- wrap catalog filter buttons in a horizontal scroller container for touch-friendly browsing
- add styles for the new category carousel and keep legacy wrapper transparent
- enable drag and wheel-driven horizontal scrolling via a utility in main.js

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cbe1487bfc83288ab1beb499c35cb9