### PR TITLE
Implement horizontal category carousel

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -81,36 +81,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function makeHorizontalScroll(el) {
     if (!el) return;
-    let isDown = false;
-    let startX = 0;
-    let scrollLeft = 0;
+    let isDown = false, startX = 0, scrollLeft = 0;
 
-    // Drag to scroll (мышью)
+    // Drag-to-scroll
     el.addEventListener('mousedown', (e) => {
         isDown = true;
-        startX = e.pageX - el.offsetLeft;
+        startX = e.pageX - el.getBoundingClientRect().left;
         scrollLeft = el.scrollLeft;
         el.classList.add('dragging');
     });
-    window.addEventListener('mouseup', () => {
-        isDown = false;
-        el.classList.remove('dragging');
-    });
-    el.addEventListener('mouseleave', () => {
-        isDown = false;
-        el.classList.remove('dragging');
-    });
+    window.addEventListener('mouseup', () => { isDown = false; el.classList.remove('dragging'); });
+    el.addEventListener('mouseleave', () => { isDown = false; el.classList.remove('dragging'); });
     el.addEventListener('mousemove', (e) => {
         if (!isDown) return;
         e.preventDefault();
-        const x = e.pageX - el.offsetLeft;
-        const walk = (x - startX);
-        el.scrollLeft = scrollLeft - walk;
+        const x = e.pageX - el.getBoundingClientRect().left;
+        el.scrollLeft = scrollLeft - (x - startX);
     });
 
-    // Вертикальное колесо → горизонтальный скролл
+    // Вертикальное колесо -> горизонтальный скролл
     el.addEventListener('wheel', (e) => {
-        // если пользователь крутит вертикально — скроллим вбок
         if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
             el.scrollLeft += e.deltaY;
             e.preventDefault();
@@ -118,9 +108,8 @@ function makeHorizontalScroll(el) {
     }, { passive: false });
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    const scroller = document.getElementById('catScroller');
-    makeHorizontalScroll(scroller);
+document.addEventListener('DOMContentLoaded', () => {
+    makeHorizontalScroll(document.getElementById('catRow'));
 });
 
 // Catalog filtering functionality

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -591,6 +591,47 @@ body {
 
 .category-filters { display: contents; }
 
+/* Горизонтальная карусель в ОДНУ строку */
+.category-row {
+    display: flex;
+    flex-wrap: nowrap;          /* ключ: запретить перенос */
+    align-items: center;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+    width: 100%;
+    max-width: 100%;
+    min-height: 48px;           /* высота ряда под кнопки */
+    padding-bottom: 8px;        /* место под (тонкий) скроллбар */
+    overscroll-behavior-x: contain;
+    /* защищаемся от переносов изнутри */
+    white-space: nowrap;
+    min-width: 0;               /* не раздуваться шире контейнера */
+}
+
+/* Кнопки не сжимаются и не переносятся */
+.category-row .filter-btn {
+    flex: 0 0 auto;             /* фиксированный размер, только скролл */
+    display: inline-flex;       /* чтобы white-space работал ожидаемо */
+    scroll-snap-align: start;
+    white-space: nowrap;
+    /* на случай глобальных margin у .filter-btn — используем только gap */
+    margin: 0;
+}
+
+/* косметика скроллбара (опционально) */
+.category-row::-webkit-scrollbar { height: 6px; }
+.category-row::-webkit-scrollbar-track { background: transparent; }
+.category-row::-webkit-scrollbar-thumb {
+    background: hsl(30 12% 88%);
+    border-radius: 4px;
+}
+
+/* если где-то остался старый блок .category-фilters, чтобы не ломал сетку */
+.category-filters { display: contents; }
+
 .no-products {
     text-align: center;
     padding: 60px 0;

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -16,7 +16,7 @@
             <div class="container">
                 <!-- Category Filters -->
                 <div class="category-filters">
-                    <div class="category-scroller" id="catScroller" aria-label="Категории">
+                    <div class="category-row" id="catRow" aria-label="Категории">
                         <button class="filter-btn {% if not active_category %}active{% endif %}" onclick="filterProducts('all'); window.location.href='{% url 'catalog' %}{% if q %}?q={{ q|urlencode }}{% endif %}';">Все</button>
                         {% for category in categories %}
                         <button class="filter-btn {% if active_category and active_category.id == category.id %}active{% endif %}" onclick="filterProducts('{{ category.name }}'); window.location.href='{% url 'catalog' %}?category={{ category.slug }}{% if q %}&q={{ q|urlencode }}{% endif %}';">{{ category.name }}</button>


### PR DESCRIPTION
## Summary
- wrap catalog category buttons in the new `.category-row` container required for the carousel
- style the category row to stay in a single horizontal line with scroll snapping and custom scrollbar cosmetics
- update the horizontal scroll helper to target the new row and support drag and vertical wheel scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbf91df6b88328b4f35d18e43b44de