### PR TITLE
Adjust footer contacts layout for mobile

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -139,12 +139,14 @@ def index(request):
         .first()
     )
     company = CompanyInfo.objects.first()
+    contacts = company
     context = {
         "carousel": carousel,
         "main_products": main_products,
         "metrics": metrics,
         "home_video": home_video,
         "company": company,
+        "contacts": contacts,
         "active_page": "home",
     }
     return render(request, "index.html", context)
@@ -176,6 +178,7 @@ def catalog(request):
     query_params = request.GET.copy()
     query_params.pop("page", None)
     query_string = query_params.urlencode()
+    contacts = CompanyInfo.objects.first()
     context = {
         "categories": categories,
         "page_obj": page_obj,
@@ -185,6 +188,7 @@ def catalog(request):
         "q": q,
         "query_string": query_string,
         "category_slug": category_slug,
+        "contacts": contacts,
     }
     return render(request, "catalog.html", context)
 
@@ -194,13 +198,16 @@ def product_detail(request, slug: str):
         Product.objects.select_related("category"), slug=slug, is_active=True
     )
     images = product.images.all().order_by("-is_primary", "ordering", "id")
+    contacts = CompanyInfo.objects.first()
     return render(
         request,
         "product_detail.html",
-        {"product": product,
-         "images": images,
-         'active_page': 'catalog'
-         },
+        {
+            "product": product,
+            "images": images,
+            "active_page": "catalog",
+            "contacts": contacts,
+        },
     )
 
 
@@ -215,6 +222,7 @@ def about(request):
         .first()
     )
     company = CompanyInfo.objects.first()
+    contacts = company
     context = {
         "advantages": advantages,
         "metrics": metrics,
@@ -222,7 +230,8 @@ def about(request):
         "values": values,
         "about_video": about_video,
         "company": company,
-        'active_page': 'about'
+        "contacts": contacts,
+        "active_page": "about",
     }
     return render(request, "about.html", context)
 
@@ -355,6 +364,7 @@ def contact_view(request):
                 "consent": False,
             }
 
+    contacts = CompanyInfo.objects.first()
     context = {
         "addresses": addresses,
         "phones": phones,
@@ -366,6 +376,7 @@ def contact_view(request):
         "form_success": form_success,
         "active_page": "contact",
         "social": social,
+        "contacts": contacts,
     }
     status = 200 if not form_errors else 400
     return render(request, "contact.html", context, status=status)

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -1174,6 +1174,10 @@ a:focus {
     font-size: 14px;
 }
 
+.footer-contacts .contact-item--mobile {
+    display: none;
+}
+
 .footer-bottom {
     border-top: 1px solid var(--border);
     padding-top: 24px;
@@ -1245,7 +1249,41 @@ a:focus {
     .footer-grid {
         grid-template-columns: 1fr;
         gap: 32px;
-        text-align: center;
+        text-align: left;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    .footer-nav {
+        text-align: left;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    .footer-nav ul {
+        width: 100%;
+    }
+
+    .footer-contacts {
+        text-align: left;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    .footer-contacts .contact-item {
+        align-items: flex-start;
+    }
+
+    .footer-contacts .contact-item--desktop {
+        display: none;
+    }
+
+    .footer-contacts .contact-item--mobile {
+        display: flex;
     }
 
     .category-filters {

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,29 +123,116 @@
 
                 <div class="footer-contacts">
                     <h3>Контакты</h3>
-                    {% if footer_addresses %}
-                    <div class="contact-item">
-                        <span class="icon">📍</span>
-                        <span>
-                            {% for a in footer_addresses %}
-                                {% if a.title %}<strong>{{ a.title }}</strong><br>{% endif %}
-                                {% if a.city %}{{ a.city }}, {% endif %}{{ a.address }}{% if not forloop.last %}<br>{% endif %}
-                            {% endfor %}
-                        </span>
-                    </div>
-                    {% endif %}
-                    {% for p in footer_phones %}
-                    <div class="contact-item">
-                        <span class="icon">📞</span>
-                        <a href="tel:{{ p.phone }}">{% if p.label %}{{ p.label }}: {% endif %}{{ p.phone }}</a>
-                    </div>
-                    {% endfor %}
-                    {% for e in footer_emails %}
-                    <div class="contact-item">
-                        <span class="icon">✉️</span>
-                        <a href="mailto:{{ e.email }}">{% if e.label %}{{ e.label }}: {% endif %}{{ e.email }}</a>
-                    </div>
-                    {% endfor %}
+                    {% with company_contacts=contacts.contacts %}
+                        {% if footer_addresses %}
+                        <div class="contact-item contact-item--desktop">
+                            <span class="icon">📍</span>
+                            <span>
+                                {% for a in footer_addresses %}
+                                    {% if a.title %}<strong>{{ a.title }}</strong><br>{% endif %}
+                                    {% if a.city %}{{ a.city }}{% if a.address %}, {% endif %}{% endif %}{{ a.address }}{% if not forloop.last %}<br>{% endif %}
+                                {% endfor %}
+                            </span>
+                        </div>
+                        {% endif %}
+                        {% with primary_address=footer_addresses|first %}
+                            {% if primary_address %}
+                                <div class="contact-item contact-item--mobile">
+                                    <span class="icon">📍</span>
+                                    <span>
+                                        {% if primary_address.address or primary_address.city %}
+                                            {% if primary_address.title %}<strong>{{ primary_address.title }}</strong><br>{% endif %}
+                                            {% if primary_address.city %}{{ primary_address.city }}{% if primary_address.address %}, {% endif %}{% endif %}
+                                            {% if primary_address.address %}{{ primary_address.address }}{% endif %}
+                                        {% else %}
+                                            {{ primary_address }}
+                                        {% endif %}
+                                    </span>
+                                </div>
+                            {% elif company_contacts and company_contacts.addresses %}
+                                {% with primary_address=company_contacts.addresses.0 %}
+                                    {% if primary_address %}
+                                    <div class="contact-item contact-item--mobile">
+                                        <span class="icon">📍</span>
+                                        <span>
+                                            {% if primary_address.address or primary_address.city %}
+                                                {% if primary_address.title %}<strong>{{ primary_address.title }}</strong><br>{% endif %}
+                                                {% if primary_address.city %}{{ primary_address.city }}{% if primary_address.address %}, {% endif %}{% endif %}
+                                                {% if primary_address.address %}{{ primary_address.address }}{% endif %}
+                                            {% else %}
+                                                {{ primary_address }}
+                                            {% endif %}
+                                        </span>
+                                    </div>
+                                    {% endif %}
+                                {% endwith %}
+                            {% endif %}
+                        {% endwith %}
+
+                        {% for p in footer_phones %}
+                        <div class="contact-item contact-item--desktop">
+                            <span class="icon">📞</span>
+                            <a href="tel:{{ p.phone }}">{% if p.label %}{{ p.label }}: {% endif %}{{ p.phone }}</a>
+                        </div>
+                        {% endfor %}
+                        {% with primary_phone=footer_phones|first %}
+                            {% if primary_phone %}
+                                <div class="contact-item contact-item--mobile">
+                                    <span class="icon">📞</span>
+                                    {% if primary_phone.phone %}
+                                        <a href="tel:{{ primary_phone.phone }}">{% if primary_phone.label %}{{ primary_phone.label }}: {% endif %}{{ primary_phone.phone }}</a>
+                                    {% else %}
+                                        <a href="tel:{{ primary_phone }}">{{ primary_phone }}</a>
+                                    {% endif %}
+                                </div>
+                            {% elif company_contacts and company_contacts.phones %}
+                                {% with primary_phone=company_contacts.phones.0 %}
+                                    {% if primary_phone %}
+                                    <div class="contact-item contact-item--mobile">
+                                        <span class="icon">📞</span>
+                                        {% if primary_phone.phone %}
+                                            <a href="tel:{{ primary_phone.phone }}">{% if primary_phone.label %}{{ primary_phone.label }}: {% endif %}{{ primary_phone.phone }}</a>
+                                        {% else %}
+                                            <a href="tel:{{ primary_phone }}">{{ primary_phone }}</a>
+                                        {% endif %}
+                                    </div>
+                                    {% endif %}
+                                {% endwith %}
+                            {% endif %}
+                        {% endwith %}
+
+                        {% for e in footer_emails %}
+                        <div class="contact-item contact-item--desktop">
+                            <span class="icon">✉️</span>
+                            <a href="mailto:{{ e.email }}">{% if e.label %}{{ e.label }}: {% endif %}{{ e.email }}</a>
+                        </div>
+                        {% endfor %}
+                        {% with primary_email=footer_emails|first %}
+                            {% if primary_email %}
+                                <div class="contact-item contact-item--mobile">
+                                    <span class="icon">✉️</span>
+                                    {% if primary_email.email %}
+                                        <a href="mailto:{{ primary_email.email }}">{% if primary_email.label %}{{ primary_email.label }}: {% endif %}{{ primary_email.email }}</a>
+                                    {% else %}
+                                        <a href="mailto:{{ primary_email }}">{{ primary_email }}</a>
+                                    {% endif %}
+                                </div>
+                            {% elif company_contacts and company_contacts.emails %}
+                                {% with primary_email=company_contacts.emails.0 %}
+                                    {% if primary_email %}
+                                    <div class="contact-item contact-item--mobile">
+                                        <span class="icon">✉️</span>
+                                        {% if primary_email.email %}
+                                            <a href="mailto:{{ primary_email.email }}">{% if primary_email.label %}{{ primary_email.label }}: {% endif %}{{ primary_email.email }}</a>
+                                        {% else %}
+                                            <a href="mailto:{{ primary_email }}">{{ primary_email }}</a>
+                                        {% endif %}
+                                    </div>
+                                    {% endif %}
+                                {% endwith %}
+                            {% endif %}
+                        {% endwith %}
+                    {% endwith %}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- provide `contacts` context data in all HTML views for footer rendering
- update the footer template to show only the first address, phone, and email on mobile while keeping full details on desktop
- tweak footer CSS so navigation and contact blocks align left on small screens

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d0ff7d26c0832897ecd548c57e50a9