### PR TITLE
Improve catalog filter scrolling and styles

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -298,11 +298,20 @@ document.addEventListener('DOMContentLoaded', function() {
         // обновляем URL (без перезагрузки)
         params.delete("partial");
         const baseSearch = params.toString();
-        const url = baseSearch ? `${window.location.pathname}?${baseSearch}#grid` : `${window.location.pathname}#grid`;
-        window.history.pushState({cat: slug}, "", url);
+        const cleanUrl = baseSearch ? `${window.location.pathname}?${baseSearch}` : `${window.location.pathname}`;
+        const targetState = {cat: slug};
+        const urlWithHash = `${cleanUrl}#grid`;
+
+        window.history.pushState(targetState, "", urlWithHash);
+
+        if (location.hash) {
+          window.history.replaceState(targetState, "", cleanUrl);
+        }
 
         // оставаться на месте: скролл к гриду (на всякий случай)
-        document.getElementById("grid")?.scrollIntoView({block: "start", behavior: "smooth"});
+        document.getElementById("grid")?.scrollIntoView({behavior: "smooth", block: "start"});
+
+        window.history.replaceState(targetState, "", urlWithHash);
       } catch (err) {
         // фоллбек: обычная навигация с якорем
         params.delete("partial");

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -613,6 +613,13 @@ a:focus {
     transition: all 0.3s;
     font-size: 14px;
     font-weight: 500;
+    text-decoration: none;
+}
+
+.filter-btn:focus,
+.filter-btn:hover,
+.filter-btn:active {
+    text-decoration: none;
 }
 
 .filter-btn:hover,


### PR DESCRIPTION
## Summary
- smooth the catalog category scroll into view and reset the URL hash before triggering it
- restore the hash after scrolling so history entries stay consistent
- prevent filter buttons from showing underlines in any interaction state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2535d54008328abddc3a4b634fedc