### PR TITLE
Implement sticky header transparency transitions

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -1,8 +1,37 @@
 // Mobile menu functionality
 function toggleMobileMenu() {
     const mobileMenu = document.getElementById('mobileMenu');
+    if (!mobileMenu) {
+        return;
+    }
+
     mobileMenu.classList.toggle('active');
+
+    if (typeof window.__updateSiteHeaderState === 'function') {
+        window.__updateSiteHeaderState();
+    }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const header = document.querySelector('.site-header');
+    if (!header) {
+        return;
+    }
+
+    const updateHeaderState = () => {
+        const solid = window.scrollY > 40;
+        header.classList.toggle('is-solid', solid);
+        header.classList.toggle('is-transparent', !solid);
+        document.body.style.setProperty('--header-h', header.offsetHeight + 'px');
+    };
+
+    window.__updateSiteHeaderState = updateHeaderState;
+
+    updateHeaderState();
+    window.addEventListener('scroll', updateHeaderState, { passive: true });
+    window.addEventListener('resize', updateHeaderState);
+    window.addEventListener('load', updateHeaderState);
+});
 
 // Hero slider functionality
 let currentSlide = 0;

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -15,6 +15,8 @@ html {
     --brand-gold-2: #e8c07a;
     --brand-ink: #322417;
     --bg: #f6ede2;
+    --header-bg: #f6ede2;
+    --header-h: 64px;
     --text-main: #3f2c21;
     --text-muted: #7a5b45;
     --muted: #7a5b45;
@@ -26,6 +28,7 @@ body {
     line-height: 1.6;
     color: var(--text-main);
     background-color: var(--bg);
+    padding-top: var(--header-h, 0px);
 }
 
 a {
@@ -47,11 +50,66 @@ a:focus {
 
 /* Header */
 .header {
-    background: var(--bg);
+    background: var(--header-bg, var(--bg));
     box-shadow: 0 2px 16px rgba(138, 87, 56, 0.08);
     position: sticky;
     top: 0;
     z-index: 1000;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+    backdrop-filter: saturate(160%) blur(6px);
+}
+
+.site-header.is-transparent {
+    background: rgba(0, 0, 0, 0.08);
+    box-shadow: none;
+}
+
+.site-header.is-transparent .nav-link,
+.site-header.is-transparent .logo-main,
+.site-header.is-transparent .logo-accent,
+.site-header.is-transparent .mobile-menu-btn {
+    color: #fff;
+}
+
+.site-header.is-transparent .hamburger,
+.site-header.is-transparent .hamburger::before,
+.site-header.is-transparent .hamburger::after {
+    background: #fff;
+}
+
+.site-header.is-transparent .nav-link:hover,
+.site-header.is-transparent .nav-link:focus,
+.site-header.is-transparent .nav-link.active {
+    color: var(--brand-brown);
+}
+
+.site-header.is-solid {
+    background: var(--header-bg, #f7efe5);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.site-header.is-solid .nav-link {
+    color: var(--text-muted);
+}
+
+.site-header.is-solid .mobile-menu-btn {
+    color: var(--brand-brown);
+}
+
+.site-header.is-solid .hamburger,
+.site-header.is-solid .hamburger::before,
+.site-header.is-solid .hamburger::after {
+    background: var(--brand-brown);
+}
+
+.site-header.is-transparent .site-logo img {
+    filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.25)) brightness(1.15);
 }
 
 .nav-wrapper {
@@ -1196,6 +1254,34 @@ a:focus {
 
 /* Responsive Design */
 @media (max-width: 768px) {
+    .site-header {
+        background: var(--header-bg, #f7efe5) !important;
+    }
+
+    .site-header .nav-link,
+    .site-header .nav-link-mobile,
+    .site-header .mobile-menu-btn {
+        color: var(--brand-ink) !important;
+    }
+
+    .site-header .hamburger,
+    .site-header .hamburger::before,
+    .site-header .hamburger::after {
+        background: var(--brand-ink) !important;
+    }
+
+    .site-header .logo-main {
+        color: var(--brand-brown) !important;
+    }
+
+    .site-header .logo-accent {
+        color: var(--brand-gold) !important;
+    }
+
+    .site-header .site-logo img {
+        filter: none !important;
+    }
+
     .nav-desktop {
         display: none;
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <!-- Header -->
-    <header class="header">
+    <header class="header site-header is-transparent">
         <div class="container">
             <div class="nav-wrapper">
                 <a href="/" class="logo" aria-label="Samruk Mebel - главная">


### PR DESCRIPTION
## Summary
- add the `site-header` modifiers to the base template so the header can switch between transparent and solid modes
- extend the main stylesheet with transparent/solid header styles, mobile fallbacks, and a body padding offset that uses the header height
- update the main script to toggle header state on scroll/resize and sync the body offset, while keeping the mobile menu height in sync

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d25bfa4fcc8328b4b597e0b1a37ba0